### PR TITLE
Do not restore self-provisioners role when master is restarted

### DIFF
--- a/setup_cluster.sh
+++ b/setup_cluster.sh
@@ -153,8 +153,7 @@ function setup_logging() {
 
 # https://docs.openshift.com/container-platform/4.2/applications/projects/configuring-project-creation.html#disabling-project-self-provisioning_configuring-project-creation
 function remove_self_provisioner_role() {
- # oc annotate clusterrolebinding.rbac self-provisioners 'rbac.authorization.kubernetes.io/autoupdate=false'
-  oc patch clusterrolebinding.rbac self-provisioners -p '{"subjects": null}'
+  oc patch clusterrolebinding.rbac self-provisioners -p '{"subjects": null, "metadata": {"annotations":{"rbac.authorization.kubernetes.io/autoupdate": "false"}}}'
   oc adm policy remove-cluster-role-from-group self-provisioner system:authenticated:oauth
 }
 


### PR DESCRIPTION
This PR disables auto update of the self-provisioners role when the master is restarted. It fixes the problem with our cluster updates. During the update the master is restarted and the users can create namespaces again.