### PR TITLE
Switch Serverless operator to 4.3 channel

### DIFF
--- a/config/operators/che/che_cluster.yaml
+++ b/config/operators/che/che_cluster.yaml
@@ -16,6 +16,7 @@ spec:
       CHE_WORKSPACE_DEFAULT__CPU__REQUEST__CORES: '0.03'
       CHE_WORKSPACE_SIDECAR_DEFAULT__CPU__LIMIT__CORES: '0.2'
       CHE_WORKSPACE_SIDECAR_DEFAULT__CPU__REQUEST__CORES: '0.03'
+      CHE_WORKSPACE_STOP_ROLE_ENABLED: 'true'
     selfSignedCert: false
     tlsSupport: true
     allowUserDefinedWorkspaceNamespaces: false

--- a/config/operators/che/che_cluster.yaml
+++ b/config/operators/che/che_cluster.yaml
@@ -23,5 +23,5 @@ spec:
     cheFlavor: che
   storage:
     preCreateSubPaths: true
-    pvcClaimSize: 5Gi
+    pvcClaimSize: 3Gi
     pvcStrategy: per-workspace

--- a/config/operators/che/subscription.yaml
+++ b/config/operators/che/subscription.yaml
@@ -24,4 +24,4 @@ spec:
   name: eclipse-che
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: eclipse-che.v7.11.0
+  startingCSV: eclipse-che.v7.12.0

--- a/config/operators/pipelines/subscription.yaml
+++ b/config/operators/pipelines/subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: openshift-pipelines-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: openshift-pipelines-operator.v0.11.1
+  startingCSV: openshift-pipelines-operator.v0.11.2

--- a/config/operators/serverless/serving_subscription.yaml
+++ b/config/operators/serverless/serving_subscription.yaml
@@ -10,9 +10,9 @@ metadata:
   name: serverless-operator
   namespace: openshift-operators
 spec:
-  channel: preview-4.3
+  channel: 4.3
   installPlanApproval: Automatic
   name: serverless-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: serverless-operator.v1.6.0
+  startingCSV: serverless-operator.v1.7.0


### PR DESCRIPTION
- Switch Serverless operator to `4.3` channel and update it to 1.7.0
- Update Pipelines to 0.11.2
- Update Che to 7.12.0
- Enable Che Workspace Idling
- 3Gi for Che Workspace PVC instead of 5Gi