### PR TITLE
No default limits for Knative services

### DIFF
--- a/config/operators/serverless/knative_serving.yaml
+++ b/config/operators/serverless/knative_serving.yaml
@@ -17,10 +17,10 @@ spec:
       stable-window: 60s
       tick-interval: 2s
     defaults:
-      revision-cpu-limit: 1000m
-      revision-cpu-request: 400m
+      revision-cpu-limit: 150m
+      revision-cpu-request: 10m
       revision-memory-limit: 200M
-      revision-memory-request: 100M
+      revision-memory-request: 64M
       revision-timeout-seconds: '300'
     deployment:
       registriesSkippingTagResolving: 'ko.local,dev.local'

--- a/config/operators/serverless/knative_serving.yaml
+++ b/config/operators/serverless/knative_serving.yaml
@@ -17,10 +17,6 @@ spec:
       stable-window: 60s
       tick-interval: 2s
     defaults:
-      revision-cpu-limit: 150m
-      revision-cpu-request: 10m
-      revision-memory-limit: 200M
-      revision-memory-request: 64M
       revision-timeout-seconds: '300'
     deployment:
       registriesSkippingTagResolving: 'ko.local,dev.local'


### PR DESCRIPTION
No default limits for Knative services so the ones from the LimitRange is used.