### PR TITLE
Add ingress label to knative namespace to match NetworkPolicy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ host_*-*
 member_*-*
 
 tmp
+temp

--- a/config/operators/serverless/serving_subscription.yaml
+++ b/config/operators/serverless/serving_subscription.yaml
@@ -2,6 +2,8 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: knative-serving
+  labels:
+    network.openshift.io/policy-group: ingress
 spec: {}
 ---
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
We need to add a label to the knative-serving namespace to match the selector we currently use in user's NetworkPolicy to make serverless routes accessible: https://github.com/codeready-toolchain/host-operator/blob/master/deploy/templates/nstemplatetiers/basic/ns_dev.yaml#L60