### PR TITLE
feat: add ClusterRole to view Tekton resources

### DIFF
--- a/config/cluster_role.yaml
+++ b/config/cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-view
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch

--- a/setup_cluster.sh
+++ b/setup_cluster.sh
@@ -144,6 +144,13 @@ function setup_tools_operators() {
   fi
 }
 
+function setup_cluster_role() {
+  if [[ ${CLUSTER_TYPE} == "member" ]]; then
+    # Create necessary ClusterRole
+    oc apply -f ./config/cluster_role.yaml
+  fi
+}
+
 function setup_cluster() {
   echo "cluster type:$CLUSTER_TYPE"
   CONFIG_MANIFESTS=${CLUSTER_TYPE}_$(date +"%Y_%m_%d-%H_%M_%S")
@@ -221,3 +228,4 @@ deploy_operators
 setup_logging
 setup_autoscaler
 setup_tools_operators
+setup_cluster_role


### PR DESCRIPTION
add ClusterRole (to the member cluster) that gives the read permissions (get,list,watch) of the Tekton resources

related PR: https://github.com/codeready-toolchain/host-operator/pull/216