### PR TITLE
Adding configmap for hostoperator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,13 +112,20 @@ Authentication is required in order to interact with the Mailgun API. The value 
 export MAILGUN_API_KEY=your-mailgun-api-key
 ----
 
-
 === MAILGUN_SENDER_EMAIL
 The sender's email address is required in order to interact with the Mailgun API. The value of this environment variable must be base64 encoded.
 
 [source]
 ----
 export MAILGUN_SENDER_EMAIL=your-mailgun-senders-email-address
+----
+
+=== REGISTRATION_SERVICE_URL
+The url where the registration-service is running.
+
+[source]
+----
+export REGISTRATION_SERVICE_URL=registration-service-url
 ----
 
 == Setting up Toolchain on Host and Member cluster

--- a/config/host-operator-config.yaml
+++ b/config/host-operator-config.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: ${NAMESPACE}
 type: Opaque
 data:
-  registration.service.url: ${REG_SERVICE_URL}
+  registration.service.url: ${REGISTRATION_SERVICE_URL}

--- a/config/host-operator-config.yaml
+++ b/config/host-operator-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: host-operator-config
+  namespace: ${NAMESPACE}
+type: Opaque
+data:
+  registration.service.url: ${REG_SERVICE_URL}

--- a/setup_cluster.sh
+++ b/setup_cluster.sh
@@ -76,6 +76,7 @@ function deploy_operators() {
   if [[ ${CLUSTER_TYPE} == "host" ]]; then
     oc new-project "$HOST_OPERATOR_NS"
     MAILGUN_DOMAIN=$MAILGUN_DOMAIN MAILGUN_API_KEY=$MAILGUN_API_KEY NAMESPACE=$HOST_OPERATOR_NS envsubst < ./config/host_operator_secret.yaml | oc apply -f -
+    REGISTRATION_SERVICE_URL=$REGISTRATION_SERVICE_URL NAMESPACE=$HOST_OPERATOR_NS envsubst < ./config/host_operator_config.yaml | oc apply -f -
     NAME=host-operator OPERATOR_NAME=toolchain-host-operator NAMESPACE=$HOST_OPERATOR_NS envsubst < ./config/operator_deploy.yaml | oc apply -f -
     oc apply -f ./config/reg_service_route.yaml
   else


### PR DESCRIPTION
adding configMap for host operator as discussed here: https://github.com/codeready-toolchain/host-operator/pull/238#discussion_r453135255

this adds the registration service url 

related to: https://github.com/codeready-toolchain/host-operator/pull/244