### PR TITLE
[crw] switching PVC strategy from 'common' to 'per-workspace'

### DIFF
--- a/config/operators/che/che_cluster.yaml
+++ b/config/operators/che/che_cluster.yaml
@@ -27,5 +27,5 @@ spec:
     cheFlavor: che
   storage:
     preCreateSubPaths: true
-    pvcClaimSize: 10Gi
-    pvcStrategy: common
+    pvcClaimSize: 2Gi
+    pvcStrategy: per-workspace

--- a/config/operators/crw/crw.yaml
+++ b/config/operators/crw/crw.yaml
@@ -27,5 +27,5 @@ spec:
     cheFlavor: codeready-workspaces
   storage:
     preCreateSubPaths: true
-    pvcClaimSize: 10Gi
-    pvcStrategy: common
+    pvcClaimSize: 2Gi
+    pvcStrategy: per-workspace


### PR DESCRIPTION
Comparrsion table 

| # of workspaces | # of PVC (common) | # of PVC (per-workspace)|
| ------------- | ------------- |----------|
| initialy (no workspace have been started )  | 0  | 0 |
| 1   | 1 (10Gi)  | 1 (2Gi) |
| 2   | 1 (10Gi)  | 2 (2Gi each) |
| 3   | 1 (10Gi)  | 3 (2Gi each) |
| 5   | 1 (10Gi)  | 5 (2Gi each) |
| 0 (all workspaces have been removed)  | 1 (10 Gi) | 0 (all PVC removed) 

Docs https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/1.0/html/administration_guide/codeready-workspaces_administration_guide

