### PR TITLE
Switch installer from Che to CRW operator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -144,22 +144,6 @@ The console route name. If CONSOLE_ROUTE_NAME env var is not provided, it will d
 export CONSOLE_ROUTE_NAME=console-route-name
 ----
 
-=== CHE_NAMESPACE
-The che namespace. If CHE_NAMESPACE env var is not provided, it will default to "codeready-workspaces-operator"
-
-[source]
-----
-export CHE_NAMESPACE=che-namespace
-----
-
-=== CHE_ROUTE_NAME
-The name of the Che dashboard route. If CHE_ROUTE_NAME env var is not provided, it will default to "codeready"
-
-[source]
-----
-export CHE_ROUTE_NAME=che-route-name
-----
-
 === IDENTITY_PROVIDER
 The identity provider. If IDENTITY_PROVIDER env var is not provided, it will default to "rhd"
 

--- a/README.adoc
+++ b/README.adoc
@@ -145,7 +145,7 @@ export CONSOLE_ROUTE_NAME=console-route-name
 ----
 
 === CHE_NAMESPACE
-The che namespace. If CHE_NAMESPACE env var is not provided, it will default to "toolchain-che"
+The che namespace. If CHE_NAMESPACE env var is not provided, it will default to "codeready-workspaces-operator"
 
 [source]
 ----
@@ -153,7 +153,7 @@ export CHE_NAMESPACE=che-namespace
 ----
 
 === CHE_ROUTE_NAME
-The name of the Che dashboard route. If CHE_ROUTE_NAME env var is not provided, it will default to "che"
+The name of the Che dashboard route. If CHE_ROUTE_NAME env var is not provided, it will default to "codeready"
 
 [source]
 ----

--- a/config/host_operator_config.yaml
+++ b/config/host_operator_config.yaml
@@ -8,5 +8,3 @@ data:
   registration.service.url: ${REGISTRATION_SERVICE_URL}
   console.namespace: ${CONSOLE_NAMESPACE)
   console.route.name: ${CONSOLE_ROUTE_NAME)
-  che.namespace: ${CHE_NAMESPACE}
-  che.route.name: ${CHE_ROUTE_NAME}

--- a/config/operators/crw/crw.yaml
+++ b/config/operators/crw/crw.yaml
@@ -2,7 +2,7 @@ apiVersion: org.eclipse.che/v1
 kind: CheCluster
 metadata:
   name: codeready-workspaces
-  namespace: workspaces
+  namespace: codeready-workspaces-operator
 spec:
   auth:
     externalIdentityProvider: false

--- a/config/operators/crw/subscription.yaml
+++ b/config/operators/crw/subscription.yaml
@@ -1,27 +1,27 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: workspaces
+  name: codeready-workspaces-operator
 spec: {}
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: workspaces
-  namespace: workspaces
+  name: codeready-workspaces-operator
+  namespace: codeready-workspaces-operator
 spec:
   targetNamespaces:
-    - workspaces
+    - codeready-workspaces-operator
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: codeready-workspaces
-  namespace: workspaces
+  namespace: codeready-workspaces-operator
 spec:
   channel: latest
   installPlanApproval: Automatic
   name: codeready-workspaces
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: crwoperator.v2.1.1
+  startingCSV: crwoperator.v2.5.0

--- a/setup_cluster.sh
+++ b/setup_cluster.sh
@@ -85,11 +85,11 @@ function deploy_operators() {
       echo "setting up default CONSOLE_ROUTE_NAME i.e. $CONSOLE_ROUTE_NAME "
     fi
     if [[ -z ${CHE_NAMESPACE} ]]; then
-      export $CHE_NAMESPACE="toolchain-che"
+      export $CHE_NAMESPACE="codeready-workspaces-operator"
       echo "setting up default CHE_NAMESPACE i.e. $CHE_NAMESPACE "
     fi
     if [[ -z ${CHE_ROUTE_NAME} ]]; then
-      export $CHE_ROUTE_NAME="che"
+      export $CHE_ROUTE_NAME="codeready"
       echo "setting up default CHE_ROUTE_NAME i.e. $CHE_ROUTE_NAME "
     fi
     REGISTRATION_SERVICE_URL=$REGISTRATION_SERVICE_URL CONSOLE_NAMESPACE=$CONSOLE_NAMESPACE CONSOLE_ROUTE_NAME=$CONSOLE_ROUTE_NAME CHE_NAMESPACE=$CHE_NAMESPACE CHE_ROUTE_NAME=$CHE_ROUTE_NAME NAMESPACE=$HOST_OPERATOR_NS envsubst < ./config/host_operator_config.yaml | oc apply -f -
@@ -128,16 +128,16 @@ function setup_autoscaler() {
 
 function setup_tools_operators() {
   if [[ ${CLUSTER_TYPE} == "member" ]]; then
-    # Che
+    # CRW
     # namespace, operator-group, subscription
-    oc apply -f ./config/operators/che/subscription.yaml
+    oc apply -f ./config/operators/crw/subscription.yaml
     while [[ "checlusters.org.eclipse.che" != $(oc get crd checlusters.org.eclipse.che -o jsonpath='{.metadata.name}' 2>/dev/null) ]]; do
       echo "waiting for CheCluster CRD to be available..."
       sleep 1
     done
     # CheCluster
-    oc apply -f ./config/operators/che/che_cluster.yaml
-    echo "Che operator installed"
+    oc apply -f ./config/operators/crw/crw.yaml
+    echo "CRW operator installed"
 
     # Pipelines
     # subscription
@@ -161,7 +161,7 @@ function setup_tools_operators() {
     echo "OpenShift Serverless operator installed"
 
     # Swich to Manual
-    oc patch subscription eclipse-che -n toolchain-che -p '{"spec":{"installPlanApproval":"Manual"}}' --type=merge
+    oc patch subscription codeready-workspaces -n codeready-workspaces-operator -p '{"spec":{"installPlanApproval":"Manual"}}' --type=merge
     oc patch subscription serverless-operator -n openshift-operators -p '{"spec":{"installPlanApproval":"Manual"}}' --type=merge
     oc patch subscription openshift-pipelines-operator -n openshift-operators -p '{"spec":{"installPlanApproval":"Manual"}}' --type=merge
   fi

--- a/setup_cluster.sh
+++ b/setup_cluster.sh
@@ -84,15 +84,7 @@ function deploy_operators() {
       export $CONSOLE_ROUTE_NAME="console"
       echo "setting up default CONSOLE_ROUTE_NAME i.e. $CONSOLE_ROUTE_NAME "
     fi
-    if [[ -z ${CHE_NAMESPACE} ]]; then
-      export $CHE_NAMESPACE="codeready-workspaces-operator"
-      echo "setting up default CHE_NAMESPACE i.e. $CHE_NAMESPACE "
-    fi
-    if [[ -z ${CHE_ROUTE_NAME} ]]; then
-      export $CHE_ROUTE_NAME="codeready"
-      echo "setting up default CHE_ROUTE_NAME i.e. $CHE_ROUTE_NAME "
-    fi
-    REGISTRATION_SERVICE_URL=$REGISTRATION_SERVICE_URL CONSOLE_NAMESPACE=$CONSOLE_NAMESPACE CONSOLE_ROUTE_NAME=$CONSOLE_ROUTE_NAME CHE_NAMESPACE=$CHE_NAMESPACE CHE_ROUTE_NAME=$CHE_ROUTE_NAME NAMESPACE=$HOST_OPERATOR_NS envsubst < ./config/host_operator_config.yaml | oc apply -f -
+    REGISTRATION_SERVICE_URL=$REGISTRATION_SERVICE_URL CONSOLE_NAMESPACE=$CONSOLE_NAMESPACE CONSOLE_ROUTE_NAME=$CONSOLE_ROUTE_NAME NAMESPACE=$HOST_OPERATOR_NS envsubst < ./config/host_operator_config.yaml | oc apply -f -
     NAME=host-operator OPERATOR_NAME=toolchain-host-operator NAMESPACE=$HOST_OPERATOR_NS envsubst < ./config/operator_deploy.yaml | oc apply -f -
     oc apply -f ./config/reg_service_route.yaml
   else


### PR DESCRIPTION
- Installer now installs CRW instead of Che
- Updates CRW to 2.5.0
- Changes the CRW Operator namespace name to the same namespace which is used by the CRW Addon in OSD (just for consistency and simplifying configuration)
- Deletes the obsolete Che (namespace, route) configuration from the host operator