### PR TITLE
feat: install Grafana with Prometheus Operator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,6 +78,12 @@ export ISSUER=your_issuer_url
 
 If you have not set this variable, script will use default issuer i.e. "https://sso.redhat.com/auth/realms/redhat-external" which points for RH SSO
 
+=== MAPPING
+
+By default, the mapping method for the Identity Provider is `lookup`, which means that the `user` and `identity` resources MUST exist on the cluster before the user logs in.
+
+However, for testing purposes on a temp cluster, the `MAPPING` env var can be explicitely set to `claim`, in which case the `user` and `identity` resources will be created during the login.
+
 === PULL_SECRET
 We are storing host, member and 48 hrs temp clusters configuration files under `/config` directory, for which we need pull secrets to be set by the environment variable `PULL_SECRET`
 

--- a/config/monitoring/grafana_app.tmpl.yaml
+++ b/config/monitoring/grafana_app.tmpl.yaml
@@ -1,0 +1,239 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: grafana-app-template
+  annotations:
+    tags: "grafana,monitoring"
+labels:
+  # will be applied on all objects defined below
+  app: grafana 
+parameters:
+- name: NAMESPACE
+  description: The namespace in which to create these Grafana resources
+  required: true
+- name: NAME
+  description: The name to use for these resources to create
+  value: grafana
+- name: SA_NAME
+  description: The name of the Service Account 
+  required: true
+- name: THANOS_QUERIER_URL_HOST
+  description: the URL to the Thanos Querier instance on the Host Cluster
+  required: true
+- name: PROMETHEUS_OPERATED_URL_HOST
+  description: the URL to the Prometheus operated instance on the Host Cluster
+  required: true
+- name: BEARER_TOKEN_HOST
+  description: The bearer token to authenticate to Thanos Querier on the Host Cluster
+  required: true
+- name: THANOS_QUERIER_URL_MEMBER
+  description: the URL to the Thanos Querier instance on the Member Cluster
+  required: true
+- name: BEARER_TOKEN_MEMBER
+  description: The bearer token to authenticate to Thanos Querier on the Member Cluster
+  required: true
+
+objects:
+
+# Route to the Grafana Service 
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    namespace: ${NAMESPACE}
+    name: ${NAME}
+  spec:
+    to:
+      name: ${NAME}
+    tls:
+      termination: Reencrypt
+
+# Service to the Grafana deployment (via the oauth-proxy sidecar container)
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: grafana-tls
+  spec:
+    ports:
+    - name: grafana
+      port: 443
+      targetPort: 8443
+    selector:
+      app: ${NAME}
+
+# Deploy Grafana with an oauth-proxy sidecar container
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    namespace: ${NAMESPACE}
+    name: ${NAME}
+    labels:
+      app: ${NAME}
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ${NAME}
+    template:
+      metadata:
+        namespace: ${NAMESPACE}
+        name: ${NAME}
+        labels:
+          app: ${NAME}
+      spec:
+        serviceAccountName: ${SA_NAME}
+        containers:
+        - name: oauth-proxy
+          image: openshift/oauth-proxy:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8443
+            name: public
+          args:
+          - --https-address=:8443
+          - --provider=openshift
+          - --openshift-service-account=${SA_NAME}
+          - --upstream=http://localhost:3000
+          - --tls-cert=/etc/tls/private/tls.crt
+          - --tls-key=/etc/tls/private/tls.key
+          - --cookie-secret=SECRET
+          - --pass-basic-auth=true
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: grafana-tls
+        - image: docker.io/grafana/grafana:7.3.0
+          imagePullPolicy: Always
+          name: grafana
+          env:
+          - name: GF_AUTH_BASIC_ENABLED
+            value: 'false'
+          - name: GF_AUTH_PROXY_ENABLED
+            value: 'true'
+          - name: GF_AUTH_PROXY_HEADER_NAME
+            value: 'X-Forwarded-User'
+          - name: GF_AUTH_PROXY_HEADER_PROPERTY
+            value: 'username'
+          - name: GF_AUTH_PROXY_AUTO_SIGN_UP
+            value: 'true'
+          - name: GF_AUTH_PROXY_ENABLE_LOGIN_TOKEN
+            value: 'true'
+          - name: GF_AUTH_DISABLE_LOGIN_FORM
+            value: 'false'
+          - name: GF_USERS_ALLOW_SIGN_UP
+            value: 'false'
+          - name: GF_USERS_DEFAULT_THEME
+            value: 'light'
+          - name: GF_SECURITY_ADMIN_USER
+            value: 'xcoulon'
+          - name: GF_PATHS_CONFIG # see https://grafana.com/docs/grafana/latest/administration/configure-docker/#default-paths
+            value: '/etc/grafana/grafana.ini'
+          - name: GF_PATHS_PROVISIONING # see https://grafana.com/docs/grafana/latest/administration/configure-docker/#default-paths
+            value: '/etc/grafana/provisioning'
+          ports:
+          - containerPort: 3000
+            name: http
+            protocol: TCP
+          resources: {}
+          securityContext: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /etc/grafana/provisioning/datasources
+            name: grafana-prometheus-ds
+          - mountPath: /etc/grafana/provisioning/dashboards
+            name: grafana-dashboards
+          - mountPath: /var/lib/grafana/dashboards
+            name: grafana-sandbox-dashboard
+        volumes:
+          - name: grafana-tls
+            secret:
+              secretName: grafana-tls
+          - name: grafana-prometheus-ds
+            configMap:
+              name: grafana-prometheus-ds
+          - name: grafana-dashboards
+            configMap:
+              name: grafana-dashboards
+          - name: grafana-sandbox-dashboard
+            configMap:
+              name: grafana-sandbox-dashboard
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 60
+
+# ConfigMap to specify the connection to Prometheus
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    namespace: ${NAMESPACE}
+    name: grafana-prometheus-ds
+  data:
+    user-workload-monitoring.prometheus.yaml: |
+      apiVersion: 1
+      datasources:
+      - name: Host Cluster/Thanos Querier
+        orgId: 1
+        version: 1
+        type: prometheus
+        access: proxy
+        url: ${THANOS_QUERIER_URL_HOST}
+        basicAuth: false
+        withCredentials: true
+        isDefault: false
+        jsonData:
+          httpHeaderName1: 'Authorization'
+          timeInterval: 5s
+          tlsSkipVerify: true
+        secureJsonData:
+          httpHeaderValue1: 'Bearer ${BEARER_TOKEN_HOST}'
+      - name: Host Cluster/Prometheus Operated
+        orgId: 1
+        version: 1
+        type: prometheus
+        access: proxy
+        url: ${PROMETHEUS_OPERATED_URL_HOST}
+        basicAuth: false
+        withCredentials: true
+        isDefault: false
+        jsonData:
+          httpHeaderName1: 'Authorization'
+          timeInterval: 5s
+          tlsSkipVerify: true
+        secureJsonData:
+          httpHeaderValue1: 'Bearer ${BEARER_TOKEN_HOST}'
+      - name: Member Cluster/Thanos Querier
+        orgId: 1
+        version: 1
+        type: prometheus
+        access: proxy
+        url: ${THANOS_QUERIER_URL_MEMBER}
+        basicAuth: false
+        withCredentials: true
+        isDefault: false
+        jsonData:
+          httpHeaderName1: 'Authorization'
+          timeInterval: 5s
+          tlsSkipVerify: true
+        secureJsonData:
+          httpHeaderValue1: 'Bearer ${BEARER_TOKEN_MEMBER}'
+      
+
+# ConfigMap to the Dashboards and where to store them 
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    namespace: ${NAMESPACE}
+    name: grafana-dashboards
+  data:
+    default.yaml: |
+      apiVersion: 1
+      providers:
+        - name: Default     # A uniquely identifiable name for the provider
+          folder:           # The default folder
+          type: file
+          options:
+            path: /var/lib/grafana/dashboards

--- a/config/monitoring/grafana_serviceaccount.tmpl.yaml
+++ b/config/monitoring/grafana_serviceaccount.tmpl.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: grafana-serviceaccount-template
+  annotations:
+    tags: "grafana,monitoring"
+labels:
+  # will be applied on all objects defined below
+  app: grafana 
+parameters:
+- name: NAMESPACE
+  description: The namespace in which to create these Grafana resources
+  required: true
+- name: NAME
+  description: The name of the ServiceAccount to create
+  required: true
+
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: ${NAME}
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana"}}'
+

--- a/config/monitoring/prometheus.tmpl.yaml
+++ b/config/monitoring/prometheus.tmpl.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: prometheus-template
+  annotations:
+    tags: "prometheus,monitoring"
+labels:
+  # will be applied on all objects defined below
+  app: prometheus 
+parameters:
+- name: NAMESPACE
+  description: The namespace in which to install the Prometheus Operator
+  required: true
+- name: SA_NAME
+  description: The name of the local Service Account to use to connect to Prometheus
+  required: true
+
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: ${NAMESPACE}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: kube-rbac-proxy
+  rules:
+  - apiGroups: 
+    - authentication.k8s.io
+    resources:
+    - tokenreviews
+    verbs: 
+    - "create"
+  - apiGroups: 
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    verbs: 
+    - "create"
+
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    namespace: ${NAMESPACE}
+    name: prometheus
+    labels:
+      operators.coreos.com/prometheus.${NAMESPACE}: ""
+  spec:
+    channel: beta
+    installPlanApproval: Automatic
+    name: prometheus
+    source: community-operators
+    sourceNamespace: openshift-marketplace
+    startingCSV: prometheusoperator.0.37.0
+
+# Prometheus itself (via a custom resource)
+- apiVersion: monitoring.coreos.com/v1
+  kind: Prometheus
+  metadata:
+    namespace: ${NAMESPACE}
+    name: prometheus
+  spec:
+    serviceAccountName: prometheus-k8s
+    # namespaceSelector:
+    #   any: true
+    serviceMonitorSelector:
+      matchLabels:
+        name: host-operator
+    resources:
+      requests:
+        memory: 400Mi
+    enableAdminAPI: false
+    portName: unsecured
+    containers:
+    - name: kube-rbac-proxy
+      # same as `pod/prometheus-k8s-0` in `openshift-monitoring` ns
+      # image:  quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c75977f28becdf4f7065cfa37233464dd31208b1767e620c4f19658f53f8ff8c
+      image:  quay.io/brancz/kube-rbac-proxy:v0.8.0 # upstream repo
+      imagePullPolicy: IfNotPresent
+      ports:
+      - containerPort: 9092
+        name: secured
+        resources:
+          requests:
+            cpu: 1m
+            memory: 20Mi
+      args:
+      - --secure-listen-address=0.0.0.0:9092
+      - --upstream=http://127.0.0.1:9090
+      - --tls-cert-file=/etc/tls/private/tls.crt
+      - --tls-private-key-file=/etc/tls/private/tls.key
+      - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+      - --logtostderr=true
+      - --v=10
+      volumeMounts:
+      - mountPath: /etc/tls/private
+        name: secret-prometheus-tls
+    volumes:
+    - name: secret-prometheus-tls
+      secret:
+        secretName: prometheus-tls
+
+# Service to the Prometheus deployment (via the kube-rbac-proxy sidecar container)
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: ${NAMESPACE}
+    name: prometheus-operated-secured
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: prometheus-tls
+  spec:
+    ports:
+    - name: prometheus-operated-secured
+      port: 8443
+      targetPort: 9092
+    selector:
+      app: prometheus
+
+# Route to the Prometheus (via the kube-rbac-proxy sidecar container)
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    namespace: ${NAMESPACE}
+    name: prometheus
+  spec:
+    to:
+      kind: Service
+      name: prometheus-operated-secured
+    tls:
+      termination: reencrypt
+      insecureEdgeTerminationPolicy: Redirect

--- a/config/monitoring/sandbox-dashboard.json
+++ b/config/monitoring/sandbox-dashboard.json
@@ -1,0 +1,475 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1606131551303,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "-- Mixed --",
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": "Host Cluster/Thanos Querier",
+          "expr": "pod:container_cpu_usage:sum{pod=~'host-operator-.*',namespace=~'.*-host-operator'}*1000",
+          "interval": "",
+          "legendFormat": "host-operator",
+          "refId": "A"
+        },
+        {
+          "datasource": "Member Cluster/Thanos Querier",
+          "expr": "pod:container_cpu_usage:sum{pod=~'member-operator-.*',namespace=~'.*-member-operator'}*1000",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "member-operator",
+          "refId": "B"
+        },
+        {
+          "datasource": "Host Cluster/Thanos Querier",
+          "expr": "pod:container_cpu_usage:sum{pod=~'registration-service-.*',namespace=~'.*-host-operator'}*1000",
+          "interval": "",
+          "legendFormat": "registration-service",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Operator CPU Usage (milli)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:444",
+          "decimals": 1,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:445",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "Host Cluster/Prometheus Operated",
+      "description": "Tracking the total number of MasterUserRecord resources",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "max": 3000,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2500
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.3.0",
+      "targets": [
+        {
+          "expr": "sum(sandbox_master_user_record_current)",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "current",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Active users (total)",
+      "type": "gauge"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "-- Mixed --",
+      "decimals": 1,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": "Host Cluster/Thanos Querier",
+          "expr": "sum(container_memory_working_set_bytes{pod=~'host-operator-.*',namespace=~'.*-host-operator',container='',}) BY (pod, namespace)",
+          "interval": "",
+          "legendFormat": "host-operator",
+          "refId": "A"
+        },
+        {
+          "datasource": "Member Cluster/Thanos Querier",
+          "expr": "sum(container_memory_working_set_bytes{pod=~'member-operator-.*',namespace=~'.*-member-operator',container='',}) BY (pod, namespace)",
+          "interval": "",
+          "legendFormat": "member-operator",
+          "refId": "B"
+        },
+        {
+          "datasource": "Host Cluster/Thanos Querier",
+          "expr": "sum(container_memory_working_set_bytes{pod=~'registration-service-.*',namespace=~'.*-host-operator',container='',}) BY (pod, namespace)",
+          "interval": "",
+          "legendFormat": "registration-service",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Operator Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:514",
+          "decimals": 1,
+          "format": "bytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:515",
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Host Cluster/Prometheus Operated",
+      "decimals": 2,
+      "description": "Tracking evolution of approved, deactivated and banned users",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (service) (rate(sandbox_user_signups_approved_total[5m]))*60",
+          "interval": "",
+          "legendFormat": "approved/min",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (service) (rate(sandbox_user_signups_deactivated_total[5m]))*60",
+          "interval": "",
+          "legendFormat": "deactivated/min",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (service) (rate(sandbox_user_signups_banned_total[5m]))*60",
+          "interval": "",
+          "legendFormat": "banned/min",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Activity (rate on 5m)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "Host Cluster/Thanos Querier",
+            "Host Cluster/Prometheus Operated",
+            "Member Cluster/Thanos Querier"
+          ],
+          "value": [
+            "Host Cluster/Thanos Querier",
+            "Host Cluster/Prometheus Operated",
+            "Member Cluster/Thanos Querier"
+          ]
+        },
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": true,
+        "name": "Datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sandbox",
+  "uid": "bOWZy9tGk",
+  "version": 1
+}

--- a/config/monitoring/toolchain_monitoring_namespace.tmpl.yaml
+++ b/config/monitoring/toolchain_monitoring_namespace.tmpl.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: grafana-serviceaccount-template
+  annotations:
+    tags: "grafana,monitoring"
+labels:
+  # will be applied on all objects defined below
+  app: grafana 
+parameters:
+- name: NAME
+  description: The name of the namespace to create
+  required: true
+
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: ${NAME}

--- a/config/oauth/idp.yaml
+++ b/config/oauth/idp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - mappingMethod: lookup
+  - mappingMethod: ${MAPPING}
     name: ${IDENTITY_PROVIDER}
     openID:
       claims:

--- a/config/oauth/rhd_idp_secret.yaml
+++ b/config/oauth/rhd_idp_secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-data:
-  clientSecret: ${CLIENT_SECRET}
 kind: Secret
 metadata:
-  name: rhd-idp-secret
   namespace: openshift-config
+  name: rhd-idp-secret
 type: Opaque
+data:
+  clientSecret: ${CLIENT_SECRET}

--- a/setup_cluster.sh
+++ b/setup_cluster.sh
@@ -191,22 +191,10 @@ function setup_cluster() {
 
 function login_to_cluster() {
   export KUBECONFIG=$PWD/$CONFIG_MANIFESTS/auth/kubeconfig
-  SERVER_URL=$(oc whoami --show-server)
 }
 
 function setup_idp() {
-  # setup RHD identity provider with required secret and oauth configuration
-  echo "setting up RHD identity provider"
-  if [[ -z ${ISSUER} ]]; then
-    export ISSUER="https://sso.redhat.com/auth/realms/redhat-external"
-    echo "setting up default ISSUER url i.e. $ISSUER for identity provider configuration"
-  fi
-  if [[ -z ${IDENTITY_PROVIDER} ]]; then
-    export IDENTITY_PROVIDER="rhd"
-    echo "setting up default IDENTITY_PROVIDER i.e. $IDENTITY_PROVIDER for identity provider configuration"
-  fi
-  CLIENT_SECRET=$CLIENT_SECRET envsubst <./config/oauth/rhd_idp_secret.yaml | oc apply -f -
-  IDENTITY_PROVIDER=$IDENTITY_PROVIDER ISSUER=$ISSUER envsubst <./config/oauth/idp.yaml | oc apply -f -
+  . setup_idp.sh
 }
 
 function create_crt_admins() {

--- a/setup_idp.sh
+++ b/setup_idp.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function setup_idp() {
+  # setup RHD identity provider with required secret and oauth configuration
+  echo "setting up RHD identity provider"
+  if [[ -z ${ISSUER} ]]; then
+    export ISSUER="https://sso.redhat.com/auth/realms/redhat-external"
+    echo "setting up default ISSUER url i.e. $ISSUER for identity provider configuration"
+  fi
+  if [[ -z ${IDENTITY_PROVIDER} ]]; then
+    export IDENTITY_PROVIDER="rhd"
+    echo "setting up default IDENTITY_PROVIDER i.e. $IDENTITY_PROVIDER for identity provider configuration"
+  fi
+  if [[ -z ${MAPPING} ]]; then
+    export MAPPING="lookup"
+    echo "setting up default mapping method i.e. $MAPPING for identity provider configuration"
+  fi
+  CLIENT_SECRET=$CLIENT_SECRET envsubst <./config/oauth/rhd_idp_secret.yaml | oc apply -f -
+  IDENTITY_PROVIDER=$IDENTITY_PROVIDER ISSUER=$ISSUER envsubst <./config/oauth/idp.yaml | oc apply -f -
+}
+
+if [[ -z ${CLIENT_SECRET} ]]; then
+    echo "skipping RHD identity provider setup as environment variable 'CLIENT_SECRET' is not set"
+else
+    setup_idp
+fi

--- a/setup_monitoring.sh
+++ b/setup_monitoring.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+######################################################################################
+## Install Prometheus operator
+######################################################################################
+function install_prometheus_operator() {
+  echo "📦 installing the Prometheus operator..."
+  export KUBECONFIG=$KUBECONFIG_HOST
+
+  oc process -f config/monitoring/prometheus.tmpl.yaml \
+    -p NAMESPACE="$TOOLCHAIN_OPERATOR_NS_HOST" \
+    -p SA_NAME=prometheus-k8s \
+    | oc apply -f -
+  
+  # needed by the `kube-rbac-proxy` sidecar to create TokenReviews and SubjectAccessReviews
+  oc adm policy add-cluster-role-to-user kube-rbac-proxy -z prometheus-k8s -n "$TOOLCHAIN_OPERATOR_NS_HOST"
+  
+  echo "✅ done installing Prometheus operator"
+  echo ""
+}
+
+######################################################################################
+## Deploying Grafana
+######################################################################################
+function deploy_grafana() {
+  echo "📦 deploying Grafana..."
+  # fetch the route to Thanos Querier on member cluster and 
+  export KUBECONFIG=$KUBECONFIG_MEMBER
+  THANOS_QUERIER_URL_MEMBER="https://$(oc get route/thanos-querier -n openshift-monitoring -o json | jq -r '.status.ingress[0].host')"
+  export THANOS_QUERIER_URL_MEMBER
+  echo "route to Thanos Querier on member cluster: $THANOS_QUERIER_URL_MEMBER"
+  
+  # create a `grafana` serviceaccount which is allowed to access Prometheus (via kube-rbac-proxy)
+  oc process -f config/monitoring/grafana_serviceaccount.tmpl.yaml \
+    -p NAMESPACE="$TOOLCHAIN_OPERATOR_NS_MEMBER" \
+    -p NAME=grafana \
+    | oc apply -f -
+  # needed to connect to Thanos Querier
+  oc adm policy add-cluster-role-to-user cluster-monitoring-view -z grafana -n "$TOOLCHAIN_OPERATOR_NS_MEMBER"
+  BEARER_TOKEN_MEMBER="$(oc serviceaccounts get-token grafana -n $TOOLCHAIN_OPERATOR_NS_MEMBER)"
+  export BEARER_TOKEN_MEMBER
+
+  # fetch the "local" route to Grafana on host cluster and retrieve SA token to use to connect to it
+  export KUBECONFIG=$KUBECONFIG_HOST
+  THANOS_QUERIER_URL_HOST="https://thanos-querier.openshift-monitoring.svc:9091"
+  export THANOS_QUERIER_URL_HOST
+  echo "route to Thanos Querier on host cluster: $THANOS_QUERIER_URL_HOST"
+  PROMETHEUS_OPERATED_URL_HOST="https://prometheus-operated-secured.$TOOLCHAIN_OPERATOR_NS_HOST.svc:8443"
+  export PROMETHEUS_OPERATED_URL_HOST
+  echo "route to Prometheus (operated) on host cluster: $PROMETHEUS_OPERATED_URL_HOST"
+  
+  # create a `grafana` serviceaccount which is allowed to access Thanos Querier and Prometheus operated (via kube-rbac-proxy)
+  oc process -f config/monitoring/grafana_serviceaccount.tmpl.yaml \
+    -p NAMESPACE="$TOOLCHAIN_OPERATOR_NS_HOST" \
+    -p NAME=grafana \
+    | oc apply -f -
+  # needed to connect to Thanos Querier
+  oc adm policy add-cluster-role-to-user cluster-monitoring-view -z grafana -n "$TOOLCHAIN_OPERATOR_NS_HOST"
+  BEARER_TOKEN_HOST="$(oc serviceaccounts get-token grafana -n $TOOLCHAIN_OPERATOR_NS_HOST)"
+  export BEARER_TOKEN_HOST
+
+   # use the 'oc create' commands along with the 'oc apply' to make sure the resources can be created or updated when they already exist
+  oc create configmap -n "$TOOLCHAIN_OPERATOR_NS_HOST" grafana-sandbox-dashboard \
+    --from-file=sandbox.json=config/monitoring/sandbox-dashboard.json \
+    -o yaml --dry-run=client | oc apply -f - 
+  oc process -f config/monitoring/grafana_app.tmpl.yaml \
+    -p NAMESPACE="$TOOLCHAIN_OPERATOR_NS_HOST" \
+    -p SA_NAME=grafana \
+    -p THANOS_QUERIER_URL_HOST="$THANOS_QUERIER_URL_HOST" \
+    -p PROMETHEUS_OPERATED_URL_HOST="$PROMETHEUS_OPERATED_URL_HOST" \
+    -p THANOS_QUERIER_URL_MEMBER="$THANOS_QUERIER_URL_MEMBER" \
+    -p BEARER_TOKEN_HOST="$BEARER_TOKEN_HOST" \
+    -p BEARER_TOKEN_MEMBER="$BEARER_TOKEN_MEMBER" \
+    | oc apply -f -
+  echo "✅ done with deploying Grafana on $SERVER"
+  echo ""
+  echo "🖥  https://$(oc get route/grafana -n $TOOLCHAIN_OPERATOR_NS_HOST -o json | jq -r '.status.ingress[0].host')"
+}
+
+######################################################################################
+## Main
+######################################################################################
+if [[ -z ${KUBECONFIG_HOST} ]]; then
+  echo "Missing 'KUBECONFIG_HOST' env var"
+  exit 1
+elif [[ -z ${KUBECONFIG_MEMBER} ]]; then
+  echo "Missing 'KUBECONFIG_MEMBER' env var"
+  exit 1
+elif [[ -z ${TOOLCHAIN_OPERATOR_NS_HOST} ]]; then
+  echo "Missing 'TOOLCHAIN_OPERATOR_NS_HOST' env var"
+  exit 1
+elif [[ -z ${TOOLCHAIN_OPERATOR_NS_MEMBER} ]]; then
+  echo "Missing 'TOOLCHAIN_OPERATOR_NS_MEMBER' env var"
+  exit 1
+fi
+
+export KUBECONFIG=$KUBECONFIG_HOST
+  SERVER="$(oc whoami --show-server)"
+  export SERVER
+  read -p "ℹ️  Install Prometheus operator and Grafana on $SERVER in namespace '$TOOLCHAIN_OPERATOR_NS_HOST'? (y/n) " -r
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+      exit 1
+  fi
+
+install_prometheus_operator
+deploy_grafana


### PR DESCRIPTION
While we can't enable the User Workload Monitor on
OSD, we can deploy Prometheus using the community
operator in the host-operator namespace and protect
its access with a kube-rbac-proxy sidecar (same
strategy as Thanos Querier in the `openshift-monitoring`
namespace)

Also, Grafana is deployed in the `toolchain-host-operator`
namespace and configured with the following data sources:
- Thanos Querier on the host cluster to retrieve
  the CPU and memory metrics of the host-operator and
  registration service pods
- Thanos Querier on the member cluster to retrieve
  the CPU and memory metrics of the member-operator
  pod
- Prometheus Operated to retrieve the business metrics
  on the host-operator pod (active users, etc.)

The `sandbox` dashboard exposes the CPU and memory
for all our pods (`host-operator`, `registration-service`
and `member-operator`), as well as panels to show the
current number of active users and the activity (activations,
deactivations and bans)

Fixes https://issues.redhat.com/browse/CRT-809

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
