### PR TITLE
Crw namespace label

### DIFF
--- a/config/operators/che/subscription.yaml
+++ b/config/operators/che/subscription.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: toolchain-che
   labels:
-    network.openshift.io/policy-group: ingress
+    network.openshift.io/policy-group: codeready-workspaces
 spec: {}
 ---
 apiVersion: operators.coreos.com/v1

--- a/config/operators/che/subscription.yaml
+++ b/config/operators/che/subscription.yaml
@@ -2,6 +2,8 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: toolchain-che
+  labels:
+    network.openshift.io/policy-group: ingress
 spec: {}
 ---
 apiVersion: operators.coreos.com/v1

--- a/config/operators/crw/subscription.yaml
+++ b/config/operators/crw/subscription.yaml
@@ -2,6 +2,8 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: codeready-workspaces-operator
+  labels:
+    network.openshift.io/policy-group: ingress
 spec: {}
 ---
 apiVersion: operators.coreos.com/v1

--- a/config/operators/crw/subscription.yaml
+++ b/config/operators/crw/subscription.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: codeready-workspaces-operator
   labels:
-    network.openshift.io/policy-group: ingress
+    network.openshift.io/policy-group: codeready-workspaces
 spec: {}
 ---
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
This fixes Che/CRW single-host mode caused by network policies that prohibit accessing user namespaces from Che/CRW operator namespace by adding `network.openshift.io/policy-group: ingress` label to the operator namespaces. Namespaces with such labels are allowed to access the user namespaces.
See https://github.com/eclipse/che/issues/18360#issuecomment-732413332