### PR TITLE
Add che user deletion enabled set to true

### DIFF
--- a/config/member_operator_config.yaml
+++ b/config/member_operator_config.yaml
@@ -7,5 +7,5 @@ type: Opaque
 data:
   che.namespace: "codeready-workspaces-operator"
   che.route.name: "codeready"
-  che.user.deletion.enabled: "true"
+  che.user_deletion_enabled: "true"
   identity.provider: ${IDENTITY_PROVIDER}

--- a/config/member_operator_config.yaml
+++ b/config/member_operator_config.yaml
@@ -5,4 +5,7 @@ metadata:
   namespace: ${NAMESPACE}
 type: Opaque
 data:
+  che.namespace: "codeready-workspaces-operator"
+  che.route.name: "codeready"
+  che.user.deletion.enabled: "true"
   identity.provider: ${IDENTITY_PROVIDER}


### PR DESCRIPTION
Related PR:
https://github.com/codeready-toolchain/member-operator/pull/231

Adds `che.user_deletion_enabled: "true"`

Also adds a couple things that are in the config map on staging but weren't in this file.